### PR TITLE
Add ContentType

### DIFF
--- a/src/entity/Entry.ts
+++ b/src/entity/Entry.ts
@@ -1,5 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToMany } from 'typeorm';
 import { DateRange } from './DateRange';
+import { ContentType } from '../enums';
 
 @Entity()
 export class Entry {
@@ -13,7 +14,14 @@ export class Entry {
     subjectDate: Date;
 
     @Column('text')
-    text: string;
+    content: string;
+
+    @Column({
+        type: 'simple-enum',
+        enum: ContentType,
+        default: ContentType.MARKDOWN,
+    })
+    content_type: ContentType;
 
     @ManyToMany((type) => DateRange, (dateRange) => dateRange.entries)
     dateRanges: DateRange[];

--- a/src/entity/Note.ts
+++ b/src/entity/Note.ts
@@ -1,5 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
 import { Tag } from './Tag';
+import { ContentType } from '../enums';
 
 @Entity()
 export class Note {
@@ -7,7 +8,14 @@ export class Note {
     id: number;
 
     @Column('text')
-    text: string;
+    content: string;
+
+    @Column({
+        type: 'simple-enum',
+        enum: ContentType,
+        default: ContentType.MARKDOWN,
+    })
+    content_type: ContentType;
 
     @ManyToOne((type) => Tag, (tag) => tag.notes)
     tag: Tag;

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,5 @@
+export enum ContentType {
+    PLAINTEXT = 'plaintext',
+    MARKDOWN = 'markdown',
+    HTML = 'html',
+}


### PR DESCRIPTION
Note that we use `simple-enum` instead of `enum`
because sqlite doesn't support enum, but this PR
allows a workaround by adding a `simple-enum` type.

https://github.com/typeorm/typeorm/pull/3700