### PR TITLE
Fix many-to-many relationships by removing cascades and fixing typos

### DIFF
--- a/src/entity/DateRange.ts
+++ b/src/entity/DateRange.ts
@@ -20,9 +20,7 @@ export class DateRange {
     })
     title: string;
 
-    @OneToOne((type) => Impression, (impression) => impression.dateRange, {
-        cascade: ['insert', 'update'],
-    })
+    @OneToOne((type) => Impression, (impression) => impression.dateRange)
     @JoinColumn()
     impression: Impression;
 
@@ -33,15 +31,11 @@ export class DateRange {
     })
     events: string[];
 
-    @ManyToMany((type) => Entry, (entry) => entry.dateRanges, {
-        cascade: ['insert', 'update'],
-    })
+    @ManyToMany((type) => Entry, (entry) => entry.dateRanges)
     @JoinTable()
     entries: Entry[];
 
-    @ManyToMany((type) => Entry, (entry) => entry.dateRanges, {
-        cascade: ['insert', 'update'],
-    })
+    @ManyToMany((type) => Tag, (tag) => tag.dateRanges)
     @JoinTable()
     tags: Tag[];
 }

--- a/src/entity/Entry.ts
+++ b/src/entity/Entry.ts
@@ -24,8 +24,6 @@ export class Entry {
     })
     contentType: ContentType;
 
-    @ManyToMany((type) => DateRange, (dateRange) => dateRange.entries, {
-        cascade: ['insert', 'update'],
-    })
+    @ManyToMany((type) => DateRange, (dateRange) => dateRange.entries)
     dateRanges: DateRange[];
 }

--- a/src/entity/Impression.ts
+++ b/src/entity/Impression.ts
@@ -9,9 +9,7 @@ export class Impression {
     @Column()
     written: Date;
 
-    @OneToOne((type) => DateRange, (dateRange) => dateRange.impression, {
-        cascade: ['insert', 'update'],
-    })
+    @OneToOne((type) => DateRange, (dateRange) => dateRange.impression)
     dateRange: DateRange;
 
     @Column()

--- a/src/entity/Note.ts
+++ b/src/entity/Note.ts
@@ -17,9 +17,7 @@ export class Note {
     })
     content_type: ContentType;
 
-    @ManyToOne((type) => Tag, (tag) => tag.notes, {
-        cascade: ['insert', 'update'],
-    })
+    @ManyToOne((type) => Tag, (tag) => tag.notes)
     tag: Tag;
 
     // Some notes about a person or activity are more important than others

--- a/src/entity/Tag.ts
+++ b/src/entity/Tag.ts
@@ -12,13 +12,9 @@ export class Tag {
     })
     name: string;
 
-    @ManyToMany((type) => DateRange, (dateRange) => dateRange.entries, {
-        cascade: ['insert', 'update'],
-    })
+    @ManyToMany((type) => DateRange, (dateRange) => dateRange.tags)
     dateRanges: DateRange[];
 
-    @OneToMany((type) => Note, (note) => note.tag, {
-        cascade: true,
-    })
+    @OneToMany((type) => Note, (note) => note.tag)
     notes: Note[];
 }


### PR DESCRIPTION
Cascades are a bit of syntactic sugar that makes the code more concise, but WAY harder to reason about with possible circular updates. I had such a hard time figuring out why many-to-many relationships were failing before I removed these cascades. Never again.

Also, there were some other typos that were causing many-to-many relationships to fail. Whoops.