### PR TITLE
Add Tag Views

### DIFF
--- a/src/controller/DateRangeController.ts
+++ b/src/controller/DateRangeController.ts
@@ -1,7 +1,7 @@
 import { getRepository } from 'typeorm';
 import { NextFunction, Request, Response } from 'express';
 import { DateRange } from '../entity/DateRange';
-import { getOffsetDate, dateToSqliteTimestamp } from '../utils';
+import { getOffsetDate, dateToSqliteTimestamp, arrayify } from '../utils';
 
 export class DateRangeController {
     private repo = getRepository(DateRange);
@@ -39,16 +39,9 @@ export class DateRangeController {
         // all days when tags are given. Otherwise, every single range has a tag, which we obvs
         // shouldn't show.
         if (tags) {
-            let formattedTags;
-            // TODO: figure out why TypeScript isn't catching that tags isn't a string and failing beforehand
-            if (Array.isArray(tags)) {
-                formattedTags = tags;
-            } else {
-                formattedTags = [tags];
-            }
-
             return filterWithoutTags.innerJoinAndSelect('range.tags', 'tag', 'tag.name IN (:...tags)', {
-                tags: formattedTags,
+                // TODO: figure out why TypeScript isn't catching that tags isn't a string and failing earlier
+                tags: arrayify(tags),
             });
         } else {
             return filterWithoutTags.andWhere('range.title IS NOT NULL');

--- a/src/controller/TagController.ts
+++ b/src/controller/TagController.ts
@@ -1,0 +1,15 @@
+import { getRepository } from 'typeorm';
+import { NextFunction, Request, Response } from 'express';
+import { Tag } from '../entity/Tag';
+
+export class TagController {
+    private repo = getRepository(Tag);
+
+    async all(request: Request, response: Response, next: NextFunction) {
+        return this.repo.find({ relations: ['dateRanges', 'dateRanges.entries'] });
+    }
+
+    async one(request: Request, response: Response, next: NextFunction) {
+        return this.all(request, response, next);
+    }
+}

--- a/src/controller/TagController.ts
+++ b/src/controller/TagController.ts
@@ -5,11 +5,17 @@ import { Tag } from '../entity/Tag';
 export class TagController {
     private repo = getRepository(Tag);
 
+    // link to entries, and link to range view
     async all(request: Request, response: Response, next: NextFunction) {
-        return this.repo.find({ relations: ['dateRanges', 'dateRanges.entries'] });
-    }
-
-    async one(request: Request, response: Response, next: NextFunction) {
-        return this.all(request, response, next);
+        const tags = await this.repo.find();
+        return response.render('tag', {
+            tags: tags.map((tag) => {
+                return {
+                    name: tag.name,
+                    entriesLink: `/entries?tags=${encodeURI(tag.name)}`,
+                    datesLink: `/dates?tags=${encodeURI(tag.name)}`,
+                };
+            }),
+        });
     }
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,5 +1,6 @@
 import { EntryController } from './controller/EntryController';
 import { DateRangeController } from './controller/DateRangeController';
+import { TagController } from './controller/TagController';
 
 export const Routes = [
     {
@@ -31,5 +32,11 @@ export const Routes = [
         route: '/dates/from/:start/to/:end',
         controller: DateRangeController,
         action: 'between',
+    },
+    {
+        method: 'get',
+        route: '/tags',
+        controller: TagController,
+        action: 'all',
     },
 ];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,3 +11,7 @@ export const isoToSqliteTimestamp = (isoTimestamp: string): string => {
 export const dateToSqliteTimestamp = (date: Date): string => {
     return isoToSqliteTimestamp(date.toISOString());
 };
+
+export const arrayify = (input: any[] | any): any[] => {
+    return Array.isArray(input) ? input : [input];
+};

--- a/src/views/tag.pug
+++ b/src/views/tag.pug
@@ -1,0 +1,15 @@
+doctype html
+html
+  head
+    meta(charset='utf-8')
+    style
+        include css/entry.css
+  body
+
+  each tag in tags
+    h3 #{tag.name}
+    ul
+      li
+        a(href=tag.entriesLink) Entries
+      li
+        a(href=tag.datesLink) Date Range View


### PR DESCRIPTION
Can now filter by tag for `DateRange` and `Entry` using `?tags=<tag>`, as well as link to those views from a `/tag` central page.