### PR TITLE
Add Impression View

### DIFF
--- a/src/controller/ImpressionController.ts
+++ b/src/controller/ImpressionController.ts
@@ -62,8 +62,6 @@ export class ImpressionController {
             var mma10 = plot.mma(mapping, 10).series();
             mma10.stroke('#bf360c');
 
-            plot.bbands(mapping)
-
             // get a plot scale
             yScale = plot.yScale();
 
@@ -73,12 +71,6 @@ export class ImpressionController {
 
             // Set up vertical gridlines
             plot.yMinorGrid().palette(["LightGrey", null]);
-
-            // MACD
-            var macd = chart.plot(1).macd(mapping, 12, 26, 9);
-            macd.macdSeries().stroke('#bf360c');
-            macd.signalSeries().stroke('#ff6d00');
-            macd.histogramSeries().fill('#ffe082');
 
             chart.title('Mood');
 

--- a/src/controller/ImpressionController.ts
+++ b/src/controller/ImpressionController.ts
@@ -52,25 +52,31 @@ export class ImpressionController {
             // chart type
             var chart = anychart.stock();
 
-            var plot = chart.plot(0);
+            var rangePlot = chart.plot(0);
 
-            // set the series
-            var series = plot.hilo(mapping);
-            // series.name("ACME Corp. stock prices");
+            var series = rangePlot.hilo(mapping);
+            series.name("Daily Hi-lo");
 
-            // set the indicators
-            var mma10 = plot.mma(mapping, 10).series();
-            mma10.stroke('#bf360c');
+            rangePlot.yScale().minimum(-8);
+            rangePlot.yScale().maximum(8);
 
-            // get a plot scale
-            yScale = plot.yScale();
+            var trendPlot = chart.plot(1);
 
-            // set minimum/maximum and inversion
-            yScale.minimum(-10);
-            yScale.maximum(10);
+            var ema3 = trendPlot.ema(mapping, 3).series();
+            ema3.name("3-day weighted avg");
+
+            var ema10 = trendPlot.ema(mapping, 10).series();
+            ema10.name("10-day weighted avg");
+
+            var ema30 = trendPlot.ema(mapping, 30).series();
+            ema30.name("30-day weighted avg");
+
+            trendPlot.yScale().minimum(-4);
+            trendPlot.yScale().maximum(4);
 
             // Set up vertical gridlines
-            plot.yMinorGrid().palette(["LightGrey", null]);
+            rangePlot.yMinorGrid().palette(["LightGrey", null]);
+            trendPlot.yMinorGrid().palette(["LightGrey", null]);
 
             chart.title('Mood');
 
@@ -102,11 +108,11 @@ export class ImpressionController {
                 {
                     'text': '500 Days',
                     'type': 'points',
-                    'count': 500,
+                    'count': 490,
                 },
                 {
                     'text': 'All',
-                    'type': 'all',
+                    'type': 'max',
                 },
             ];
 

--- a/src/controller/ImpressionController.ts
+++ b/src/controller/ImpressionController.ts
@@ -76,6 +76,44 @@ export class ImpressionController {
 
             chart.container('container');
             chart.draw();
+
+            var rangeSelector = anychart.ui.rangeSelector();
+            var rangePicker = anychart.ui.rangePicker();
+
+            var customRanges = [
+                {
+                    'text': 'Quarter',
+                    'type': 'unit',
+                    'unit': 'quarter',
+                    'count': 1,
+                },
+                {
+                    'text': 'Half',
+                    'type': 'unit',
+                    'unit': 'semester',
+                    'count': 1,
+                },
+                {
+                    'text': 'Year',
+                    'type': 'unit',
+                    'unit': 'year',
+                    'count': 1,
+                },
+                {
+                    'text': '500 Days',
+                    'type': 'points',
+                    'count': 500,
+                },
+                {
+                    'text': 'All',
+                    'type': 'all',
+                },
+            ];
+
+            rangeSelector.ranges(customRanges);
+
+            rangePicker.render(chart);
+            rangeSelector.render(chart);
           });
         `.trim();
     }

--- a/src/controller/ImpressionController.ts
+++ b/src/controller/ImpressionController.ts
@@ -57,6 +57,8 @@ export class ImpressionController {
             var series = rangePlot.hilo(mapping);
             series.name("Daily Hi-lo");
 
+            // rangePlot.priceChannels(mapping, 10);
+
             rangePlot.yScale().minimum(-8);
             rangePlot.yScale().maximum(8);
 
@@ -120,6 +122,21 @@ export class ImpressionController {
 
             rangePicker.render(chart);
             rangeSelector.render(chart);
+
+            chart.listen("pointDblClick", function(event){
+                var point = event.point;
+                alert(point);
+                if (!!point.get('end')) {
+                    var start = new Date(point.get('start')).toISOString().split('T')[0];
+                    var rawEnd = new Date(point.get('end'));
+                    rawEnd.setDate(rawEnd.getDate() - 1);
+                    var end = rawEnd.toISOString().split('T')[0]
+                    window.location = '/entries/from/' + start + '/to/' + end;
+                } else {
+                    var singleDate = new Date(point.get('x')).toISOString().split('T')[0]
+                    window.location = '/entries/on/' + singleDate;
+                }
+            });
           });
         `.trim();
     }

--- a/src/controller/ImpressionController.ts
+++ b/src/controller/ImpressionController.ts
@@ -1,0 +1,109 @@
+import { getRepository } from 'typeorm';
+import { NextFunction, Request, Response } from 'express';
+import { DateRange } from '../entity/DateRange';
+import { getOffsetDate, dateToSqliteTimestamp, arrayify } from '../utils';
+// import { Impression } from '../entity/Impression';
+
+export class ImpressionController {
+    private repo = getRepository(DateRange);
+
+    // Totally arbitrary
+    private MIN_YEAR = '1000';
+    private MAX_YEAR = '3000';
+
+    async all(request: Request, response: Response, next: NextFunction) {
+        request.params.start = this.MIN_YEAR;
+        request.params.end = this.MAX_YEAR;
+        return this.between(request, response, next);
+    }
+
+    async between(request: Request, response: Response, next: NextFunction) {
+        const start = dateToSqliteTimestamp(new Date(request.params.start));
+        const end = dateToSqliteTimestamp(new Date(request.params.end));
+
+        const rangesWithImpressions = await this.repo
+            .createQueryBuilder('range')
+            .where('range.start >= :start AND range.end <= :end', { start: start, end: end })
+            .innerJoinAndSelect('range.impression', 'impression')
+            .getMany();
+
+        return response.render('impression', {
+            existingJS: this.existingJS(rangesWithImpressions),
+        });
+    }
+
+    private existingJS(ranges: DateRange[]): string {
+        return `
+        var table, mapping, chart, yScale;
+        anychart.onDocumentReady(function () {
+
+            // set the data
+            table = anychart.data.table();
+            table.addData(${this.escapeArrayToExecutableJSArray(ranges.map((range) => this.rangeToJSArray(range)))});
+
+            // map the data
+            mapping = table.mapAs({
+                high: 1,
+                low: 2,
+                value: 3,
+                // close: 3,
+            });
+
+            // chart type
+            var chart = anychart.stock();
+
+            var plot = chart.plot(0);
+
+            // set the series
+            var series = plot.hilo(mapping);
+            // series.name("ACME Corp. stock prices");
+
+            // set the indicators
+            var mma10 = plot.mma(mapping, 10).series();
+            mma10.stroke('#bf360c');
+
+            plot.bbands(mapping)
+
+            // get a plot scale
+            yScale = plot.yScale();
+
+            // set minimum/maximum and inversion
+            yScale.minimum(-10);
+            yScale.maximum(10);
+
+            // Set up vertical gridlines
+            plot.yMinorGrid().palette(["LightGrey", null]);
+
+            // MACD
+            var macd = chart.plot(1).macd(mapping, 12, 26, 9);
+            macd.macdSeries().stroke('#bf360c');
+            macd.signalSeries().stroke('#ff6d00');
+            macd.histogramSeries().fill('#ffe082');
+
+            chart.title('Mood');
+
+            chart.container('container');
+            chart.draw();
+          });
+        `.trim();
+    }
+
+    private rangeToJSArray(range: DateRange): string {
+        return this.escapeArrayToExecutableJSArray([
+            this.escapeDateToStringLiteral(range.start),
+            range.impression.positivity,
+            range.impression.negativity,
+            range.impression.total,
+        ]);
+    }
+
+    private escapeArrayToExecutableJSArray(arr: unknown[]): string {
+        return `[
+            ${arr.join(',\n')}
+        ]`;
+    }
+
+    private escapeDateToStringLiteral(date: Date): string {
+        return `"${date.toISOString().split('T')[0]}"`;
+    }
+}

--- a/src/entity/Impression.ts
+++ b/src/entity/Impression.ts
@@ -18,7 +18,7 @@ export class Impression {
     @Column()
     negativity: number;
 
-    protected total: number;
+    total: number;
 
     @AfterLoad()
     setTotal() {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,6 +1,7 @@
 import { EntryController } from './controller/EntryController';
 import { DateRangeController } from './controller/DateRangeController';
 import { TagController } from './controller/TagController';
+import { ImpressionController } from './controller/ImpressionController';
 
 export const Routes = [
     {
@@ -38,5 +39,17 @@ export const Routes = [
         route: '/tags',
         controller: TagController,
         action: 'all',
+    },
+    {
+        method: 'get',
+        route: '/impressions',
+        controller: ImpressionController,
+        action: 'all',
+    },
+    {
+        method: 'get',
+        route: '/impressions/from/:start/to/:end',
+        controller: ImpressionController,
+        action: 'between',
     },
 ];

--- a/src/views/entry.pug
+++ b/src/views/entry.pug
@@ -12,5 +12,5 @@ html
   each entry in entries
     h2
       a(href=entry.link) #{entry.subjectDate} (written #{entry.writeDate})
-    h3 In ranges: #{JSON.stringify(entry.parentRanges)}
+    h3 In ranges: #{entry.parentRanges.join(", ")}
     | !{ entry.content }

--- a/src/views/impression.pug
+++ b/src/views/impression.pug
@@ -3,6 +3,8 @@ html
     meta(charset='utf-8')
     script(type="text/javascript" src="https://cdn.anychart.com/releases/8.7.1/js/anychart-core.min.js")
     script(type="text/javascript" src="https://cdn.anychart.com/releases/8.7.1/js/anychart-stock.min.js")
+    script(type="text/javascript" src="https://cdn.anychart.com/releases/8.7.1/js/anychart-ui.min.js")
+    link(rel="stylesheet" type="text/css" href="https://cdn.anychart.com/releases/8.7.1/css/anychart-ui.min.css?hcode=a0c21fc77e1449cc86299c5faa067dc4")
 
     script !{existingJS}
   body

--- a/src/views/impression.pug
+++ b/src/views/impression.pug
@@ -1,0 +1,9 @@
+html
+  head
+    meta(charset='utf-8')
+    script(type="text/javascript" src="https://cdn.anychart.com/releases/8.7.1/js/anychart-core.min.js")
+    script(type="text/javascript" src="https://cdn.anychart.com/releases/8.7.1/js/anychart-stock.min.js")
+
+    script !{existingJS}
+  body
+    div(id="container" style="width: 100%; height:100%;")


### PR DESCRIPTION
Uses AnyChart Stock charts for a holistic overall view of impressions, as well as embeds impression data into individual entries.

Sadly AnyChart doesn't allow us to listen for click events inside the charts, so we can't link to entries from within the impression view. Also, AnyChart doesn't support pre-zooming to a specific range, so we can't really go from entries view to impressions view either.