### PR TITLE
Redirect back on delete

### DIFF
--- a/src/controller/EntryController.ts
+++ b/src/controller/EntryController.ts
@@ -206,7 +206,7 @@ export class EntryController {
                 .execute();
         }
         await this.entryRepo.createQueryBuilder().delete().from(Entry).where('id = :id', { id: id }).execute();
-        return response.redirect(`/entries/on/${this.dateToSlug(entry.subjectDate)}`);
+        return response.redirect('back');
     }
 
     private parseDateOrDefault(dateSlug: string): Date {


### PR DESCRIPTION
If you're deleting an entry while in a multi-day entry view, you probably don't want to get redirected to the /entries/on/<date> view and just want to stay on your current page.