### PR TITLE
Delink DateRange and Entry

### DIFF
--- a/src/controller/EntryController.ts
+++ b/src/controller/EntryController.ts
@@ -74,12 +74,14 @@ export class EntryController {
                 editLink: this.formatEditLink(entry.id),
                 deleteLink: this.formatDeleteLink(entry.id),
                 writeDate: this.formatShortDate(entry.writeDate),
-                parentRanges: entry.dateRanges.map((range) => {
-                    return {
-                        name: this.formatParentRange(range.start, range.end, range.impression),
-                        linkParams: this.formatRangeLinkParams(range.start, range.end),
-                    };
-                }),
+                parentRanges: entry.dateRanges
+                    .sort((range1, range2) => range1.length() - range2.length())
+                    .map((range) => {
+                        return {
+                            name: this.formatParentRange(range.start, range.end, range.impression),
+                            linkParams: this.formatRangeLinkParams(range.start, range.end),
+                        };
+                    }),
             };
         });
 

--- a/src/controller/EntryController.ts
+++ b/src/controller/EntryController.ts
@@ -260,12 +260,12 @@ export class EntryController {
             });
 
             if (range.impression) {
-                await this.impressionRepo.delete(range.impression);
+                await this.impressionRepo.delete(range.impression.id);
             }
-            await this.dateRangeRepo.delete(range);
+            await this.dateRangeRepo.delete(range.id);
         }
 
-        await this.entryRepo.delete(entry);
+        await this.entryRepo.delete(entry.id);
         return response.redirect('back');
     }
 

--- a/src/controller/EntryController.ts
+++ b/src/controller/EntryController.ts
@@ -42,8 +42,13 @@ export class EntryController {
                 'dateRanges',
                 'entry.subjectDate >= dateRanges.start AND entry.subjectDate <= dateRanges.end',
             )
-            .leftJoinAndSelect('dateRanges.impression', 'impression')
-            .andWhere(IMPRESSION_QUERY, getImpressionOpts(request.query))
+            .leftJoinAndMapOne(
+                'dateRanges.impression',
+                Impression,
+                'impression',
+                `impression.id = dateRanges.impressionId AND ${IMPRESSION_QUERY}`,
+                getImpressionOpts(request.query),
+            )
             .orderBy('entry.subjectDate');
 
         const tags = request.query.tags;

--- a/src/controller/EntryController.ts
+++ b/src/controller/EntryController.ts
@@ -36,7 +36,12 @@ export class EntryController {
         let query = this.entryRepo
             .createQueryBuilder('entry')
             .where('entry.subjectDate >= :start AND entry.subjectDate <= :end', { start: start, end: end })
-            .leftJoinAndSelect('entry.dateRanges', 'dateRanges')
+            .leftJoinAndMapMany(
+                'entry.dateRanges',
+                DateRange,
+                'dateRanges',
+                'entry.subjectDate >= dateRanges.start AND entry.subjectDate <= dateRanges.end',
+            )
             .leftJoinAndSelect('dateRanges.impression', 'impression')
             .andWhere(IMPRESSION_QUERY, getImpressionOpts(request.query))
             .orderBy('entry.subjectDate');
@@ -96,7 +101,12 @@ export class EntryController {
         const entry = await this.entryRepo
             .createQueryBuilder('entry')
             .where('entry.id = :id', { id: id })
-            .leftJoinAndSelect('entry.dateRanges', 'range', 'range.start == range.end')
+            .leftJoinAndMapMany(
+                'entry.dateRanges',
+                DateRange,
+                'range',
+                'entry.subjectDate == range.start AND entry.subjectDate == range.end',
+            )
             .leftJoinAndSelect('range.impression', 'impression')
             .leftJoinAndSelect('range.tags', 'tags')
             .getOne();
@@ -178,8 +188,6 @@ export class EntryController {
 
         await this.dateRangeRepo.save(range);
 
-        console.log(range);
-
         return response.redirect(`/entries/on/${this.dateToSlug(entry.subjectDate)}`);
     }
 
@@ -190,7 +198,12 @@ export class EntryController {
         const entry = await this.entryRepo
             .createQueryBuilder('entry')
             .where('entry.id = :id', { id: id })
-            .leftJoinAndSelect('entry.dateRanges', 'range', 'range.start == range.end')
+            .leftJoinAndMapMany(
+                'entry.dateRanges',
+                DateRange,
+                'range',
+                'entry.subjectDate == range.start AND entry.subjectDate == range.end',
+            )
             .leftJoinAndSelect('range.impression', 'impression')
             .getOne();
 
@@ -225,8 +238,6 @@ export class EntryController {
 
         await this.dateRangeRepo.save(range);
 
-        console.log(range);
-
         return response.redirect(`/entries/on/${this.dateToSlug(entry.subjectDate)}`);
     }
 
@@ -235,7 +246,12 @@ export class EntryController {
         const entry = await this.entryRepo
             .createQueryBuilder('entry')
             .where('entry.id = :id', { id: id })
-            .leftJoinAndSelect('entry.dateRanges', 'range', 'range.start == range.end')
+            .leftJoinAndMapMany(
+                'entry.dateRanges',
+                DateRange,
+                'range',
+                'entry.subjectDate == range.start AND entry.subjectDate == range.end',
+            )
             .leftJoinAndSelect('range.entries', 'entries')
             .leftJoinAndSelect('range.impression', 'impression')
             .getOne();

--- a/src/entity/DateRange.ts
+++ b/src/entity/DateRange.ts
@@ -36,4 +36,8 @@ export class DateRange {
     tags: Tag[];
 
     entries: Entry[];
+
+    length(): number {
+        return this.end.getTime() - this.start.getTime();
+    }
 }

--- a/src/entity/DateRange.ts
+++ b/src/entity/DateRange.ts
@@ -31,11 +31,9 @@ export class DateRange {
     })
     events: string[];
 
-    @ManyToMany((type) => Entry, (entry) => entry.dateRanges)
-    @JoinTable()
-    entries: Entry[];
-
     @ManyToMany((type) => Tag, (tag) => tag.dateRanges)
     @JoinTable()
     tags: Tag[];
+
+    entries: Entry[];
 }

--- a/src/entity/Entry.ts
+++ b/src/entity/Entry.ts
@@ -24,6 +24,5 @@ export class Entry {
     })
     contentType: ContentType;
 
-    @ManyToMany((type) => DateRange, (dateRange) => dateRange.entries)
     dateRanges: DateRange[];
 }


### PR DESCRIPTION
Linking Entry to DateRange directly using a ManytoMany relationship is error-prone and unnecessary since `Entry.subjectDate`, `DateRange.start`, and `DateRange.end` give you enough information to re-construct the relationships.