### PR TITLE
Fixing bugs regarding impressions filters

### DIFF
--- a/src/utils/impressionUtils.ts
+++ b/src/utils/impressionUtils.ts
@@ -27,6 +27,10 @@ export const getImpressionOpts = (query: any): Record<string, string> => {
     }, {});
 };
 
+export const hasImpressionOpts = (query: any): boolean => {
+    return Object.keys(IMPRESSION_FILTER_DEFAULTS).some((key) => query[key]);
+};
+
 const parseImpressionOrDefault = (input: string, defaultValue: number): number => {
     return input ? parseFloat(input) : defaultValue;
 };


### PR DESCRIPTION
Before, there were some interesting bugs when you were trying to filter by impression.

You can't filter on impression inside a leftJoinAndSelect clause, because you'll just remove the impression for a range if the impression doesn't match the where clause, instead of removing the linked date range as a whole.

On the other hand, if you use an innerJoinAndSelect, you'll never be able to see dateRanges that lack impressions.

The solution is to only add an innerJoinAndSelect clause if impression opts are actually given.

In addition, EntryController.find needs a *two-step* filtering process because it first needs to find all entries that have a single-day daterange that matches the given impression filter, and THEN find all the dateranges (single and multi-day) that are associated with those entries.

Right now this works for my personal use case where impression filtering is mostly used for single day dateranges, but this could get interesting when I try to filter on multi-day dateranges. I may need to think about how hierarchy/inheritance of tags, impressions, etc. applies with multi-day dateranges.