### PR TITLE
Chunk Entry Queries

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const SQLITE_MAXIMUM_VARIABLE_NUMBER = 999;

--- a/src/utils/arrayUtils.ts
+++ b/src/utils/arrayUtils.ts
@@ -1,3 +1,11 @@
 export const arrayify = (input: any[] | any): any[] => {
     return Array.isArray(input) ? input : [input];
 };
+
+export const splitArray = (array: any[], splitSize: number) => {
+    const splits = [];
+    for (let i = 0; i < array.length; i += splitSize) {
+        splits.push(array.slice(i, i + splitSize));
+    }
+    return splits;
+};


### PR DESCRIPTION
SQLite has a default maximum number of variables when using IN queries. This causes SQLite to fail when too many entries match the initial sql query. See https://www.sqlite.org/limits.html#max_variable_number for more information.

Currently, sqlite3 version 4.2.0 uses sqlite binary 3.24.0, which has `SQLITE_MAXIMUM_VARIABLE_NUMBER = 999`. Upgrading to sqlite >= 3.32 would allow for that maximum number to be 32766, but that hasn't been done yet. Track progress of that upgrade in https://github.com/mapbox/node-sqlite3/issues/1340.